### PR TITLE
Handle empty response in pagination

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -132,6 +132,11 @@
         while (nrow(tmp_response) == self$MAX_API_LIMIT) {
             query$offset <- offset
             tmp_response <- .single_request(self, url, query, uncached)
+            # if we get an empty list or data.frame we should probably break
+            if (length(tmp_response) == 0) {
+                break
+            }
+
             tmp_response <- .cast_lists_to_vectors(tmp_response)
 
             addtl_responses <- append(addtl_responses, list(tmp_response))


### PR DESCRIPTION
### Description

Added a break when we detect an empty list as an API response. This typically happens when the total number of available records is a multiple of the pagination limit (1000).

### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if applicable)
- [X] All lint and unit tests passing
- [X] Extended the README / documentation, if necessary
- [ ] Updated NEWS.md

### Additional Comments

Same fix as https://github.com/American-Soccer-Analysis/asa-shiny-app/pull/169
